### PR TITLE
NO-JIRA: DOWNSTREAM: <carry>: OWNERS: bump

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,13 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
 approvers:
-  - ahrtr           # Benjamin Wang <benjamin.ahrtr@gmail.com> <benjamin.wang@broadcom.com>
-  - serathius       # Marek Siarkowicz <siarkowicz@google.com> <marek.siarkowicz@gmail.com>
-  - ptabor          # Piotr Tabor <piotr.tabor@gmail.com>
-  - spzala          # Sahdev Zala <spzala@us.ibm.com>
+- deads2k
+- hasbro17
+- dusk125
+- Elbehery
+- tjungblu
 reviewers:
-  - pav-kv          # Pavel Kalinnikov <pavel@cockroachlabs.com>
-emeritus_approvers:
-  - tbg             # Tobias Grieger <tobias.b.grieger@gmail.com>
+- deads2k
+- dusk125
+- hasbro17
+- Elbehery
+- tjungblu
+component: "Etcd"


### PR DESCRIPTION
This PR replaces etcd-io/bbolt owners with ocp/etcd owners

cc @openshift/openshift-team-etcd 